### PR TITLE
Change to use relative import

### DIFF
--- a/ewmh/__init__.py
+++ b/ewmh/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.1.2'
 
-from ewmh.ewmh import EWMH
+from .ewmh import EWMH


### PR DESCRIPTION
Fixes a bug where on python 2 importing results in an error 
because of a local module of the same name.

```
In [1]: import ewmh
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-07c02b8291f8> in <module>()
----> 1 import ewmh

/home/russell/.virtualenvs/damselfly/lib/python2.7/site-packages/ewmh/__init__.py in <module>()
      1 __version__ = '0.1.2'
      2 
----> 3 from ewmh.ewmh import EWMH

ImportError: No module named ewmh
```
