### PR TITLE
Use the new official python-xlib package

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2016-08-12  Hugo Osvaldo Barrera <hugo@barrera.io>
+
+	rely on upstream python-xlib package for all python versions
+
 2016-05-20  Julien Pagès  <j.parkouss@gmail.com>
 
 	released 0.1.4

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Contributors
 ------------
 
 * Reuben Thomas <rrt@sc3d.org>
+* Hugo Osvaldo Barrera <hugo@barrera.io>
 
 Thanks also to
 --------------

--- a/README.rst
+++ b/README.rst
@@ -13,21 +13,11 @@ Installation
 .. image:: https://pypip.in/version/ewmh/badge.png
     :target: https://pypi.python.org/pypi/ewmh/
 
-With Python 3, simply:
+Simply run:
 
 .. code-block:: shell
   
   pip install ewmh
-
-Unfortunately for Python 2 users, you will have to manually install
-the required dependency **Xlib** from https://pypi.python.org/pypi/python-xlib/0.12,
-until the xlib developers upload a Python 2 version to PyPi.
-
-Once this is done, just
-
-.. code-block:: shell
-  
-  python setup.py install
 
 Documentation
 -------------

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,8 @@ except ImportError:
     from distutils.core import setup
 import sys, re
 
-if sys.version > '3':
-    install_requires = ['python3-xlib']
-else:
-    # I can not specify Xlib as a dependency now as there is no
-    # release for python2 on PyPi
-    install_requires = []
-    if sys.version_info < (2, 6):
-        sys.exit("ewmh >= 0.1.3 requires python >= 2.6")
+if sys.version_info < (2, 6):
+    sys.exit("ewmh >= 0.1.3 requires python >= 2.6")
 
 setup(name='ewmh',
       version=re.findall("__version__ = '(.+)'", open('ewmh/__init__.py').read())[0],
@@ -21,6 +15,6 @@ setup(name='ewmh',
       author_email="j.parkouss@gmail.com",
       url='https://github.com/parkouss/pyewmh',
       packages=['ewmh'],
-      install_requires=install_requires,
+      install_requires=['python-xlib'],
       license='LGPL',
 )


### PR DESCRIPTION
Upstream now supports both python2.7 and python3, so we can now always rely on python-xlib.