### PR TITLE
TypeError exception when getting PID for windows that don't have one

### DIFF
--- a/ewmh/ewmh.py
+++ b/ewmh/ewmh.py
@@ -346,7 +346,8 @@ class EWMH:
         :param win: the window object
         :return: int
         """
-        return self._getProperty('_NET_WM_DESKTOP', win)[0]
+        arr = self._getProperty('_NET_WM_DESKTOP', win)
+        return arr[0] if arr else None
 
     def getWmWindowType(self, win, str=False):
         """

--- a/ewmh/ewmh.py
+++ b/ewmh/ewmh.py
@@ -397,7 +397,8 @@ class EWMH:
 
         :param win: the window object
         """
-        return self._getProperty('_NET_WM_PID', win)[0]
+        arr = self._getProperty('_NET_WM_PID', win)
+        return arr[0] if arr else None
 
     def _getProperty(self, _type, win=None):
         if not win:


### PR DESCRIPTION
At [line 400](https://github.com/parkouss/pyewmh/blob/master/ewmh/ewmh.py#L400), there is this piece of code:

    return self._getProperty('_NET_WM_PID', win)[0]

It fails with this message:

    TypeError: 'NoneType' object is not subscriptable

If no PID is found. This pull request tries to fix it.

How to reproduce:

    from ewmh import EWMH
    e = EWMH()
    print(e.getWmPid(e.root))

**WARNING!** This pull request is untested! I edited it directly inside GitHub web interface.