### PR TITLE
doc/conf.py: Fix intersphinx mapping format

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -216,6 +216,9 @@ man_pages = [
      [u'parcouss'], 1)
 ]
 
+# -- Options for intersphinx extension ---------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
 
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}


### PR DESCRIPTION
The legacy format has been deprecated since sphinx 6.2 and is now gone since sphinx 8.0: https://github.com/sphinx-doc/sphinx/pull/12083

(Snippet taken from https://github.com/sphinx-doc/sphinx/blob/master/sphinx/templates/quickstart/conf.py.jinja)